### PR TITLE
It is better to use the repository field

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "viral32111-xml"
 version = "0.1.0"
 description = "XML parser crate for my Rust projects."
-homepage = "https://github.com/viral32111/xml"
+repository = "https://github.com/viral32111/xml"
 documentation = "https://viral32111.github.io/xml/viral32111_xml"
 authors = [ "viral32111 <contact@viral32111.com>" ]
 readme = "README.md"


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.